### PR TITLE
implementing a non-interfering logging harness for dev stream to terminal

### DIFF
--- a/finmodel/src/decorators.py
+++ b/finmodel/src/decorators.py
@@ -1,0 +1,55 @@
+#####################################################################################################################################################
+# DECORATORS                                                                                                    
+#####################################################################################################################################################
+
+# Standard library imports
+import time
+import logging
+import functools
+import inspect
+
+# # Third party library imports
+# --- NONE ---
+
+# Local application imports
+# --- NONE ---
+
+# instantiating the logger
+logger = logging.getLogger(__name__) 
+logger.setLevel(logging.DEBUG) 
+formatter = logging.Formatter('%(asctime)s:   %(message)s')
+# formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(funcName)s: %(message)s') # alt format
+
+
+# # for writing to a log file 
+# file_handler = logging.FileHandler(os.path.join(write_read_path, 'log.txt'))
+# file_handler.setFormatter(formatter)
+# logger.addHandler(file_handler)
+
+# for dev stream to terminal
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
+logger.addHandler(stream_handler)
+
+
+# ====================================================================================================================================================
+def log(func):
+
+    @functools.wraps(func) 
+    def log_wrapper(*args, **kwargs): 
+        start = time.time() 
+        stack_depth = len(inspect.stack()) 
+        logger.info(f'{f"{func.__module__}":<16s}   {(int(stack_depth/2))*str("-")}↘   {func.__name__} CALLED')
+        try:
+            result = func(*args, **kwargs)
+        except Exception as e:
+            logger.exception(f'{f"{func.__module__}":<16s}   {(int(stack_depth/2))*str("-")}↗   {func.__name__} EXCEPTION: {str(e)}')
+            end = time.time()
+            logger.info(f'{f"{func.__module__}":<16s}   {(int(stack_depth/2))*str("-")}↗   {func.__name__} RUNTIME: {end-start:.4f} seconds')
+            # raise e
+        else:
+            end = time.time()
+            logger.info(f'{f"{func.__module__}":<16s}   {(int(stack_depth/2))*str("-")}↗   {func.__name__} RUNTIME: {end-start:.4f} seconds ')
+            return result 
+
+    return log_wrapper

--- a/finmodel/src/example.py
+++ b/finmodel/src/example.py
@@ -1,8 +1,20 @@
 
+#####################################################################################################################################################
 # A minimal, simplistic example
+#####################################################################################################################################################
+
+# Standard library imports
+import warnings
+
+# Third party library imports
 import pandas as pd
 import numpy as np
+
+# Local application imports
+from decorators import log
 from render import render_df
+
+warnings.simplefilter(action='ignore', category=FutureWarning) # just doing this for now I promise
 
 actl_periods = pd.PeriodIndex(pd.period_range(2019,2023,freq='A-DEC'))
 fcst_periods = pd.PeriodIndex(pd.period_range(2024,2028,freq='A-DEC'))
@@ -17,7 +29,7 @@ actuals.name='Sales'
 
 
 # instantiate metrics dict which holds the logic for defining metrics
-
+@log
 def calc_metrics(metrics_dict, actuals):#, group_by_levels=None):
     '''Calculates metrics on provided actuals.
     Returns a list of metrics.
@@ -46,12 +58,13 @@ def calc_metrics(metrics_dict, actuals):#, group_by_levels=None):
             else:
                 metrics[metric['name']] = metric['func'](actuals)
     
-    if metrics.index.equals(actuals.index):
-        print('Indexes are aligned')
-    else:
-        print('WARNING: Index of metrics is not equal to index of actuals. Alignment and calculations may not work as expected')
+    # if metrics.index.equals(actuals.index):
+    #     print('Indexes are aligned')
+    # else:
+    #     print('WARNING: Index of metrics is not equal to index of actuals. Alignment and calculations may not work as expected')
     return metrics
 
+@log
 def level_mix_calc(df, levels): # conveniently calculate percentage mix
     '''calculates the percentage mix of a particular value in an index level of a df. 
     Returns a df'''
@@ -74,6 +87,7 @@ metrics_dict = {
     }
 }
 
+@log
 def simple_growth(input,g,nper):
     '''grow input exponentially at growth rate g for nper number of periods'''
     exps = np.arange(start=1,stop=nper+1,step=1)
@@ -111,16 +125,17 @@ model_dict = { # is this more appropriate as a function somehow?
         }
 }
 
+@log
 def model_calc(model_dict, fcst_index):
     ''' takes in model dict. Returns a dataframe with index fcst_index,
     using models (function calls defined in model dict) to generate similarly indexed df'''
     placeholder = pd.DataFrame(index=fcst_index)
     model = pd.DataFrame()
     for account,values in model_dict.items():
-        print(f'modeling account: {account} with value {values["model"]}')
+        # print(f'modeling account: {account} with value {values["model"]}')
         # build the components of model df bit by bit
         result_array = values['model']
-        print(result_array)
+        # print(result_array)
         result_index = placeholder.xs(account,0,level='Account',drop_level=False).index
         result = pd.DataFrame(data=result_array,index=result_index)
         model = pd.concat([model,result],axis=0)
@@ -141,6 +156,5 @@ output = pd.concat([output,output_metrics],axis=1)
 
 
 # print(actuals)
-# print(growth)'
+# print(growth)
 render_df(output)
-

--- a/finmodel/src/render.py
+++ b/finmodel/src/render.py
@@ -15,11 +15,11 @@ from rich.panel import Panel
 from rich import print as pprint
 
 # Local application imports
-# --- NONE ---
+from decorators import log
 
 # ===================================================================================================================================================
+@log
 def render_df(df):
-
 
     # -----------------------------------------------------------------------------------------------------------------------------------------------
     # instantiating various things, configuring


### PR DESCRIPTION
This is an opinionated, but non interfering logging decorator. You can easily not use it, but it is made available to decorate with for development purposes. As an application grows in complexity, the call stack at runtime can become large and difficult to reason about when developing features and/or when debugging. This logger has no 3rd party dependencies and uses only the native python library. 

To not use it, you simply need to remove the logging decorator from functions. here is what it can tell you at run time (I've decorated functions in example.py (and turned off other printing) and render.py:

<img width="627" alt="image" src="https://github.com/tray3j/finmodel_dev/assets/147880479/4ac7f395-6a25-4782-928f-fdf3cea26875">

you can see the little dashes indicate the depth of the call stack. first, in the __main__ module (which is example.py is this is what we call from the command line) calc_metrics is CALLED, then level_mix_calc is CALLED from within calc metrics, so the call stack has gone one level deeper, and you therefore see two dashes. You can then see the two function calls terminate and their runtime is indicated. matching length dashes and upwards arrows indicate completed function runs. 

As things get complicated... this kind of thing is REALLLLLLLYYYYYY useful. Even if you dont like it, this is non-interfering... just remove the @log decoration from the functions. 

simple 